### PR TITLE
[codex] Fix Flix Renovate checksum updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "automerge": false
     },
     {
-      "description": "Keep Flix compiler updates manual because they can require source compatibility fixes and checksum refreshes.",
+      "description": "Keep Flix compiler updates manual because they can require source compatibility fixes.",
       "matchPackageNames": [
         "flix/flix"
       ],
@@ -54,7 +54,7 @@
         "FLIX_VERSION:\\s+(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\n\\s+FLIX_SHA256:\\s+(?<currentDigest>[a-f0-9]+)"
       ],
       "depNameTemplate": "flix/flix",
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "github-release-attachments",
       "versioningTemplate": "semver"
     }
   ]


### PR DESCRIPTION
## Summary

- Switch the Flix custom Renovate datasource from `github-releases` to `github-release-attachments`.
- Update the package rule description now that Renovate can refresh the release asset checksum.

## Why

PR #148 showed Renovate updating `FLIX_SHA256` to the Git commit SHA behind the release tag. That happens because `github-releases` returns the tag commit as the digest. For the downloaded `flix.jar`, Renovate needs to track the GitHub release attachment digest instead.

## Validation

- `jq empty renovate.json`
- `pnpm dlx --package renovate renovate-config-validator renovate.json`
- Checked the Flix `v0.73.0` GitHub release asset metadata contains `flix.jar` with the expected SHA256 digest.